### PR TITLE
count_unrecognized_commands: efficiency & readability

### DIFF
--- a/plugins/count_unrecognized_commands
+++ b/plugins/count_unrecognized_commands
@@ -35,7 +35,8 @@ sub hook_unrecognized_command {
   my ($self, $cmd) = @_[0,2];
   
     my $count = $self->connection->notes('unrec_cmd_count') || 0;
-                $self->connection->notes('unrec_cmd_count', $count + 1);
+       $count = $count + 1;
+                $self->connection->notes('unrec_cmd_count', $count);
 
     if ( $count < $self->{_unrec_cmd_max} ) {
         $self->log(LOGINFO, "'$cmd', ($count)");


### PR DESCRIPTION
removed hook_connect, redundant

rearranged hook_unrecognized_command for better logging and readability
