### PR TITLE
spamassassin argument subject_prefix is useless

### DIFF
--- a/plugins/spamassassin
+++ b/plugins/spamassassin
@@ -405,7 +405,7 @@ sub check_spam_munge_subject {
     };
     return DECLINED unless $sa->{score} > $required;
 
-    my $subject_prefix = $self->qp->config('subject_prefix') || '*** SPAM ***';
+    my $subject_prefix = $self->{_args}{subject_prefix} || '*** SPAM ***';
     my $subject = $transaction->header->get('Subject') || '';
     $transaction->header->replace('Subject', "$subject_prefix $subject");
 


### PR DESCRIPTION
subject_prefix isn't a config file, but a plugin argument.
