### PR TITLE
Add the message id in log

### DIFF
--- a/plugins/queue/smtp-forward
+++ b/plugins/queue/smtp-forward
@@ -73,7 +73,11 @@ sub hook_queue {
           or return (DECLINED, "Unable to queue message ($!)");
     }
     $smtp->dataend() or return (DECLINED, "Unable to queue message ($!)");
+    my $qid = $smtp->message();
+    my @list = split(' ', $qid);
+    $qid = pop(@list);
+
     $smtp->quit()    or return (DECLINED, "Unable to queue message ($!)");
     $self->log(LOGINFO, "finished queueing");
-    return (OK, "Queued!");
+    return (OK, "queued as $qid");
 }


### PR DESCRIPTION
There is no message id in logfile so it's difficult to debug a message sent through qpsmtpd.
