### PR TITLE
config parameter passing bug fix.

### DIFF
--- a/lib/Apache/Qpsmtpd.pm
+++ b/lib/Apache/Qpsmtpd.pm
@@ -58,6 +58,7 @@ sub config_dir {
         $cdir_memo{$config} = $configdir;
     }
     else {
+        shift;
         $cdir_memo{$config} = $self->SUPER::config_dir(@_);
     }
     return $cdir_memo{$config};


### PR DESCRIPTION
if config $ENV{QPSMTPD_CONFIG}, configuration path make like this.
/service/qpsmtpd/config/Qpsmtpd::Apache=HASH(0x8ab8918)
removed $self parameter form @_
