### PR TITLE
Add our headers (Received & Authentication-Results) earlier, just after DATA

### DIFF
--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -783,6 +783,8 @@ sub data_respond {
         return 1;
     }
 
+    $self->authentication_results();
+    $self->received_line();
     $self->run_hooks("data_post");
 }
 
@@ -919,8 +921,6 @@ sub data_post_respond {
         return 1;
     }
     else {
-        $self->authentication_results();
-        $self->received_line();
         $self->queue($self->transaction);
     }
 }


### PR DESCRIPTION
SpamAssassin plugin (maybe others too) expects to see our Received header. Previously, this header hasn't been added yet at that stage, leading to LOTS of SpamAssassin false positives (DOS_OUTLOOK_TO_MX, RCVD_IN_PBL, RCVD_IN_XBL, RDNS_DYNAMIC, etc).
