### PR TITLE
add --tags to 'git describe'

### DIFF
--- a/lib/Qpsmtpd.pm
+++ b/lib/Qpsmtpd.pm
@@ -1,9 +1,8 @@
 package Qpsmtpd;
 use strict;
-
 #use warnings;
 
-our $VERSION = "0.95";
+our $VERSION = '0.95';
 use vars qw($TraceLevel $Spool_dir $Size_threshold);
 
 use lib 'lib';
@@ -12,17 +11,9 @@ use Qpsmtpd::Address;
 use Qpsmtpd::Config;
 use Qpsmtpd::Constants;
 
-my $git;
-
-if (-e ".git") {
-    local $ENV{PATH} = "/usr/bin:/usr/local/bin:/opt/local/bin/";
-    $git = `git describe --tags`;
-    $git && chomp $git;
-}
-
 our $hooks = {};
-
 our $LOGGING_LOADED = 0;
+my $git = git_version();
 
 sub _restart {
     my $self = shift;
@@ -40,6 +31,16 @@ sub _restart {
 }
 
 sub version { $VERSION . ($git ? "/$git" : "") }
+
+sub git_version {
+    return if !-e '.git';
+    {
+        local $ENV{PATH} = "/usr/bin:/usr/local/bin:/opt/local/bin/";
+        $git = `git describe --tags`;
+        $git && chomp $git;
+    }
+    return $git;
+}
 
 sub TRACE_LEVEL { $TraceLevel };    # leave for plugin compatibility
 

--- a/t/packaging.t
+++ b/t/packaging.t
@@ -14,7 +14,7 @@ sub get_qp_version {
     my $rvfile = get_file_contents('lib/Qpsmtpd.pm')
         or return;
     my ($ver_line) = grep { $_ =~ /^our \$VERSION/ } @$rvfile;
-    my ($ver) = $ver_line =~ /"([0-9\.]+)"/;
+    my ($ver) = $ver_line =~ /['"]([0-9\.]+)['"]/;
     return $ver;
 };
 


### PR DESCRIPTION
'git describe' calculates the version since the last **annotated** diff. Adding --tags shows the most recent tags (v0.94, for example) regardless if they're annotated or not.
