### PR TITLE
remove test counters from plugin tests

### DIFF
--- a/t/Test/Qpsmtpd/Plugin.pm
+++ b/t/Test/Qpsmtpd/Plugin.pm
@@ -8,8 +8,8 @@ package Qpsmtpd::Plugin;
 use strict;
 use warnings;
 
-use Qpsmtpd::Constants;
 use Test::More;
+use Qpsmtpd::Constants;
 
 sub register_tests {
 
@@ -17,28 +17,17 @@ sub register_tests {
 }
 
 sub register_test {
-    my ($plugin, $test, $num_tests) = @_;
-    $num_tests = 1 unless defined($num_tests);
+    my ($plugin, $test) = @_;
 
     # print STDERR "Registering test $test ($num_tests)\n";
-    push @{$plugin->{_tests}}, {name => $test, num => $num_tests};
-}
-
-sub total_tests {
-    my ($plugin) = @_;
-    my $total = 0;
-    foreach my $t (@{$plugin->{_tests}}) {
-        $total += $t->{num};
-    }
-    return $total;
+    push @{$plugin->{_tests}}, {name => $test};
 }
 
 sub run_tests {
     my ($plugin, $qp) = @_;
     foreach my $t (@{$plugin->{_tests}}) {
         my $method = $t->{name};
-        print "# Running $method tests for plugin "
-          . $plugin->plugin_name . "\n";
+        print "# " . $plugin->plugin_name . "\t $method\n";
         local $plugin->{_qp} = $qp;
         $plugin->$method();
     }

--- a/t/plugin_tests/auth/auth_checkpassword
+++ b/t/plugin_tests/auth/auth_checkpassword
@@ -17,7 +17,7 @@ sub register_tests {
         return;
     };
 
-    $self->register_test("test_auth_checkpassword", 3);
+    $self->register_test("test_auth_checkpassword");
 }
 
 my @u_list = qw ( good bad none );

--- a/t/plugin_tests/auth/auth_flat_file
+++ b/t/plugin_tests/auth/auth_flat_file
@@ -2,7 +2,7 @@
 
 sub register_tests {
     my $self = shift;
-    $self->register_test("test_auth_flat_file", 3);
+    $self->register_test("test_auth_flat_file");
 }
 
 my @u_list = qw ( good bad none );

--- a/t/plugin_tests/auth/auth_vpopmail
+++ b/t/plugin_tests/auth/auth_vpopmail
@@ -8,7 +8,7 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test("test_auth_vpopmail", 3);
+    $self->register_test("test_auth_vpopmail");
 }
 
 my @u_list = qw ( good bad none );

--- a/t/plugin_tests/auth/auth_vpopmail_sql
+++ b/t/plugin_tests/auth/auth_vpopmail_sql
@@ -11,7 +11,7 @@ sub register_tests {
         warn "skipping auth_vpopmail_sql tests, is DBI installed?\n";
         return;
     };
-    $self->register_test("auth_vpopmail_sql", 3);
+    $self->register_test("auth_vpopmail_sql");
 }
 
 sub auth_vpopmail_sql {

--- a/t/plugin_tests/auth/auth_vpopmaild
+++ b/t/plugin_tests/auth/auth_vpopmaild
@@ -4,7 +4,7 @@ warn "loaded test auth_vpopmaild\n";
 
 sub register_tests {
     my $self = shift;
-    $self->register_test("test_auth_vpopmaild", 3);
+    $self->register_test("test_auth_vpopmaild");
 }
 
 my @u_list = qw ( good bad none );

--- a/t/plugin_tests/auth/authdeny
+++ b/t/plugin_tests/auth/authdeny
@@ -2,7 +2,7 @@
 
 sub register_tests {
     my $self = shift;
-    $self->register_test("test_authdeny", 1);
+    $self->register_test("test_authdeny");
 }
 
 sub test_authdeny {

--- a/t/plugin_tests/auth/authnull
+++ b/t/plugin_tests/auth/authnull
@@ -2,7 +2,7 @@
 
 sub register_tests {
     my $self = shift;
-    $self->register_test("test_authnull", 1);
+    $self->register_test("test_authnull");
 }
 
 sub test_authnull {

--- a/t/plugin_tests/badmailfrom
+++ b/t/plugin_tests/badmailfrom
@@ -1,7 +1,4 @@
-#!perl -w
-
 use strict;
-use Data::Dumper;
 
 use Qpsmtpd::Address;
 use Qpsmtpd::Constants;
@@ -9,9 +6,9 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test("test_badmailfrom_is_immune_sender", 5);
-    $self->register_test("test_badmailfrom_match", 7);
-    $self->register_test("test_badmailfrom_hook_mail", 4);
+    $self->register_test("test_badmailfrom_is_immune_sender");
+    $self->register_test("test_badmailfrom_match");
+    $self->register_test("test_badmailfrom_hook_mail");
 }
 
 sub test_badmailfrom_is_immune_sender {

--- a/t/plugin_tests/badmailfromto
+++ b/t/plugin_tests/badmailfromto
@@ -1,14 +1,12 @@
 #!perl -w
-
 use strict;
-use Data::Dumper;
 
 use Qpsmtpd::Address;
 
 sub register_tests {
     my $self = shift;
 
-    $self->register_test("test_badmailfromto_is_sender_immune", 5);
+    $self->register_test("test_badmailfromto_is_sender_immune");
 }
 
 sub test_badmailfromto_is_sender_immune {

--- a/t/plugin_tests/badrcptto
+++ b/t/plugin_tests/badrcptto
@@ -8,9 +8,9 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test("test_is_match", 10);
-    $self->register_test("test_hook_rcpt", 3);
-    $self->register_test("test_get_host_and_to", 8);
+    $self->register_test("test_is_match");
+    $self->register_test("test_hook_rcpt");
+    $self->register_test("test_get_host_and_to");
 }
 
 sub _reset_connection_flags {

--- a/t/plugin_tests/count_unrecognized_commands
+++ b/t/plugin_tests/count_unrecognized_commands
@@ -8,7 +8,7 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_hook_unrecognized_command', 4);
+    $self->register_test('test_hook_unrecognized_command');
 };
 
 sub test_hook_unrecognized_command {

--- a/t/plugin_tests/dmarc
+++ b/t/plugin_tests/dmarc
@@ -1,7 +1,6 @@
 #!perl -w
 
 use strict;
-use Data::Dumper;
 use POSIX qw(strftime);
 
 use Qpsmtpd::Address;
@@ -37,7 +36,6 @@ sub test_fetch_dmarc_record {
     
     foreach ( qw/ tnpi.net nictool.com / ) {
         my @matches = $self->fetch_dmarc_record($_);
-#warn Data::Dumper::Dumper(\@matches);
         cmp_ok( scalar @matches, '==', 1, 'fetch_dmarc_record');
     };
     foreach ( qw/ example.com / ) {

--- a/t/plugin_tests/dnsbl
+++ b/t/plugin_tests/dnsbl
@@ -8,10 +8,10 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_hook_connect', 1);
-    $self->register_test('test_ip_whitelisted', 3);
-    $self->register_test('test_is_set_rblsmtpd', 4);
-    $self->register_test('test_reject_type', 3);
+    $self->register_test('test_hook_connect');
+    $self->register_test('test_ip_whitelisted');
+    $self->register_test('test_is_set_rblsmtpd');
+    $self->register_test('test_reject_type');
 }
 
 sub test_ip_whitelisted {

--- a/t/plugin_tests/dspam
+++ b/t/plugin_tests/dspam
@@ -11,9 +11,9 @@ my $r;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_get_dspam_results', 6);
-    $self->register_test('test_log_and_return', 6);
-    $self->register_test('test_reject_type', 3);
+    $self->register_test('test_get_dspam_results');
+    $self->register_test('test_log_and_return');
+    $self->register_test('test_reject_type');
 }
 
 sub test_log_and_return {
@@ -79,7 +79,6 @@ sub test_get_dspam_results {
         $transaction->header->add('X-DSPAM-Result', $header);
         my $r = $self->get_dspam_results($transaction);
         ok( ref $r, "r: ($header)" );
-        #warn Data::Dumper::Dumper($r);
     };
 };
 

--- a/t/plugin_tests/earlytalker
+++ b/t/plugin_tests/earlytalker
@@ -8,14 +8,14 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_reject_type', 3);
-    $self->register_test('test_log_and_pass', 1);
-    $self->register_test('test_log_and_deny', 3);
-    $self->register_test('test_data_handler', 3);
-    $self->register_test('test_connect_handler', 3);
-    $self->register_test('test_apr_data_handler', 3);
-    $self->register_test('test_apr_connect_handler', 3);
-    $self->register_test('test_mail_handler', 4);
+    $self->register_test('test_reject_type');
+    $self->register_test('test_log_and_pass');
+    $self->register_test('test_log_and_deny');
+    $self->register_test('test_data_handler');
+    $self->register_test('test_connect_handler');
+    $self->register_test('test_apr_data_handler');
+    $self->register_test('test_apr_connect_handler');
+    $self->register_test('test_mail_handler');
 }
 
 sub test_apr_connect_handler {

--- a/t/plugin_tests/greylisting
+++ b/t/plugin_tests/greylisting
@@ -16,14 +16,14 @@ foreach ( @greydbs ) {
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_hook_data', 4);
-    $self->register_test('test_get_db_key', 4);
-    $self->register_test('test_get_db_location', 1);
-    $self->register_test("test_greylist_geoip", 7);
-    $self->register_test("test_greylist_p0f_genre", 2);
-    $self->register_test("test_greylist_p0f_distance", 2);
-    $self->register_test("test_greylist_p0f_link", 2);
-    $self->register_test("test_greylist_p0f_uptime", 2);
+    $self->register_test('test_hook_data');
+    $self->register_test('test_get_db_key');
+    $self->register_test('test_get_db_location');
+    $self->register_test("test_greylist_geoip");
+    $self->register_test("test_greylist_p0f_genre");
+    $self->register_test("test_greylist_p0f_distance");
+    $self->register_test("test_greylist_p0f_link");
+    $self->register_test("test_greylist_p0f_uptime");
 }
 
 sub test_hook_data {

--- a/t/plugin_tests/headers
+++ b/t/plugin_tests/headers
@@ -1,7 +1,6 @@
 #!perl -w
 
 use strict;
-use Data::Dumper;
 use POSIX qw(strftime);
 
 use Qpsmtpd::Address;
@@ -12,8 +11,8 @@ my $test_email = 'matt@example.com';
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_invalid_date_range', 7);
-    $self->register_test("test_hook_data_post", 7);
+    $self->register_test('test_invalid_date_range');
+    $self->register_test("test_hook_data_post");
 }
 
 sub setup_test_headers {

--- a/t/plugin_tests/helo
+++ b/t/plugin_tests/helo
@@ -8,18 +8,18 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_init_resolver', 2);
-    $self->register_test('test_is_in_badhelo', 2);
-    $self->register_test('test_is_regex_match', 3);
-    $self->register_test('test_invalid_localhost', 8);
-    $self->register_test('test_is_plain_ip', 3);
-    $self->register_test('test_is_address_literal', 3);
-    $self->register_test('test_no_forward_dns', 2);
-    $self->register_test('test_no_reverse_dns', 3);
-    $self->register_test('test_no_matching_dns', 2);
-    $self->register_test('test_helo_handler', 1);
-    $self->register_test('test_check_ip_match', 6);
-    $self->register_test('test_check_name_match', 3);
+    $self->register_test('test_init_resolver');
+    $self->register_test('test_is_in_badhelo');
+    $self->register_test('test_is_regex_match');
+    $self->register_test('test_invalid_localhost');
+    $self->register_test('test_is_plain_ip');
+    $self->register_test('test_is_address_literal');
+    $self->register_test('test_no_forward_dns');
+    $self->register_test('test_no_reverse_dns');
+    $self->register_test('test_no_matching_dns');
+    $self->register_test('test_helo_handler');
+    $self->register_test('test_check_ip_match');
+    $self->register_test('test_check_name_match');
 }
 
 sub test_helo_handler {

--- a/t/plugin_tests/ident/geoip
+++ b/t/plugin_tests/ident/geoip
@@ -14,13 +14,13 @@ sub register_tests {
         return;
     };
 
-    $self->register_test('test_geoip_lookup', 2);
-    $self->register_test('test_geoip_load_db', 2);
-    $self->register_test('test_geoip_init_cc', 2);
-    $self->register_test('test_set_country_code', 3);
-    $self->register_test('test_set_country_name', 3);
-    $self->register_test('test_set_continent', 3);
-    $self->register_test('test_set_distance', 3);
+    $self->register_test('test_geoip_lookup');
+    $self->register_test('test_geoip_load_db');
+    $self->register_test('test_geoip_init_cc');
+    $self->register_test('test_set_country_code');
+    $self->register_test('test_set_country_name');
+    $self->register_test('test_set_continent');
+    $self->register_test('test_set_distance');
 };
 
 sub test_geoip_lookup {

--- a/t/plugin_tests/ident/p0f
+++ b/t/plugin_tests/ident/p0f
@@ -8,10 +8,10 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_get_v2_query', 1);
-    $self->register_test('test_get_v3_query', 1);
-    $self->register_test('test_store_v2_results', 2);
-    $self->register_test('test_store_v3_results', 2);
+    $self->register_test('test_get_v2_query');
+    $self->register_test('test_get_v3_query');
+    $self->register_test('test_store_v2_results');
+    $self->register_test('test_store_v3_results');
 };
 
 sub test_query_p0f_v2 {
@@ -44,7 +44,6 @@ sub test_get_v2_query {
 
     my $r = $self->get_v2_query();
     ok( $r, 'r +' );
-    #use Data::Dumper; warn Data::Dumper::Dumper( $r );
 };
 
 sub test_get_v3_query {
@@ -68,7 +67,6 @@ sub test_store_v2_results {
 
     ok( $r, "r: +") or return;
     ok( $r->{genre} =~ /windows/i, "genre +" );
-    #use Data::Dumper; warn Data::Dumper::Dumper( $r );
 };
 
 sub test_store_v3_results {

--- a/t/plugin_tests/rcpt_ok
+++ b/t/plugin_tests/rcpt_ok
@@ -8,12 +8,11 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_get_rcpt_host', 7);
-    $self->register_test('test_is_in_rcpthosts', 3);
-    $self->register_test('test_is_in_morercpthosts', 2);
-    $self->register_test('test_hook_rcpt', 3);
+    $self->register_test('test_get_rcpt_host');
+    $self->register_test('test_is_in_rcpthosts');
+    $self->register_test('test_is_in_morercpthosts');
+    $self->register_test('test_hook_rcpt');
 }
-
 
 sub test_hook_rcpt {
     my $self = shift;

--- a/t/plugin_tests/relay
+++ b/t/plugin_tests/relay
@@ -8,10 +8,10 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_relay_only', 2);
-    $self->register_test('test_is_octet_match', 3);
-    $self->register_test('test_is_in_cidr_block', 4);
-    $self->register_test('test_is_in_norelayclients', 5);
+    $self->register_test('test_relay_only');
+    $self->register_test('test_is_octet_match');
+    $self->register_test('test_is_in_cidr_block');
+    $self->register_test('test_is_in_norelayclients');
 }
 
 sub test_relay_only {

--- a/t/plugin_tests/resolvable_fromhost
+++ b/t/plugin_tests/resolvable_fromhost
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 
-use Data::Dumper;
 use Net::DNS;
 use Qpsmtpd::Address;
 use Qpsmtpd::Constants;
@@ -17,12 +16,12 @@ sub register_tests {
     my %args = ( );
     $self->register( $self->qp, reject => 0 );
 
-    $self->register_test('test_populate_invalid_networks', 2);
-    $self->register_test('test_mx_address_resolves', 2);
-    $self->register_test('test_get_host_records', 2);
-    $self->register_test('test_get_and_validate_mx', 2);
-    $self->register_test('test_check_dns', 2);
-    $self->register_test('test_hook_mail', 4);
+    $self->register_test('test_populate_invalid_networks');
+    $self->register_test('test_mx_address_resolves');
+    $self->register_test('test_get_host_records');
+    $self->register_test('test_get_and_validate_mx');
+    $self->register_test('test_check_dns');
+    $self->register_test('test_hook_mail');
 }
 
 sub test_hook_mail {

--- a/t/plugin_tests/sender_permitted_from
+++ b/t/plugin_tests/sender_permitted_from
@@ -13,7 +13,7 @@ sub register_tests {
     eval 'use Mail::SPF';
     return if $@;
 
-    $self->register_test('test_is_special_recipient', 5);
+    $self->register_test('test_is_special_recipient');
 }
 
 sub test_is_special_recipient {

--- a/t/plugin_tests/spamassassin
+++ b/t/plugin_tests/spamassassin
@@ -23,11 +23,11 @@ my @sample_headers = (
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_connect_to_spamd', 4);
-    $self->register_test('test_parse_spam_header', 10);
-    $self->register_test('test_get_spam_results', 20);
-    $self->register_test('test_munge_subject', 4);
-    $self->register_test('test_reject', 2);
+    $self->register_test('test_connect_to_spamd');
+    $self->register_test('test_parse_spam_header');
+    $self->register_test('test_get_spam_results');
+    $self->register_test('test_munge_subject');
+    $self->register_test('test_reject');
 }
 
 sub test_connect_to_spamd {
@@ -48,7 +48,6 @@ sub test_connect_to_spamd {
         $self->print_to_spamd( $SPAMD, $message, $length, $username );
         shutdown($SPAMD, 1); # close our side of the socket (tell spamd we're done)
         my $headers = $self->parse_spamd_response( $SPAMD );
-        #warn Data::Dumper::Dumper($headers);
         ok( $headers, "socket response\n");
     }
     else {
@@ -61,11 +60,9 @@ sub test_connect_to_spamd {
     $SPAMD = $self->connect_to_spamd();
     if ( $SPAMD ) {
         ok( $SPAMD, "tcp/ip");
-        #warn Data::Dumper::Dumper($SPAMD);
         $self->print_to_spamd( $SPAMD, $message, $length, $username );
         shutdown($SPAMD, 1); # close our side of the socket (tell spamd we're done)
         my $headers = $self->parse_spamd_response( $SPAMD );
-        #warn Data::Dumper::Dumper($headers);
         ok( $headers, "tcp/ip response\n");
     }
     else {

--- a/t/plugin_tests/user_config
+++ b/t/plugin_tests/user_config
@@ -15,7 +15,7 @@ BEGIN {    # need this to happen before anything else
 
 sub register_tests {
     my ($self) = @_;
-    $self->register_test('test_hook_user_config', 4);
+    $self->register_test('test_hook_user_config');
 }
 
 sub test_hook_user_config {
@@ -49,10 +49,7 @@ sub test_hook_user_config {
 
 package FakeAddress;
 
-sub new {
-    shift;
-    return bless {@_};
-}
+sub new     { return bless {@_}, shift; }
 sub address { return shift->{address} }
 sub user    { return shift->{user} }
 sub host    { return shift->{host} }

--- a/t/plugin_tests/virus/clamdscan
+++ b/t/plugin_tests/virus/clamdscan
@@ -3,26 +3,27 @@
 use strict;
 use warnings;
 
+use Mail::Header;
+
 use Qpsmtpd::Constants;
 use Qpsmtpd::Transaction;
-use Mail::Header;
 
 sub register_tests {
     my $self = shift;
 
-    SKIP: {
-        eval 'use ClamAV::Client';  ## no critic (Stringy)
-        skip "Could not load ClamAV::Client", 4
-            if $@;
-        $self->register_test('test_register', 6);
-        $self->register_test('test_get_clamd', 1);
-    }
-    $self->register_test('test_err_and_return', 2);
-    $self->register_test('test_get_filename', 1);
-    $self->register_test('test_set_permission', 1);
-    $self->register_test('test_is_too_big', 2);
-    $self->register_test('test_is_multipart', 2);
-    $self->register_test('test_should_scan',4);
+    eval 'use ClamAV::Client';  ## no critic (Stringy)
+    if (!$@) {
+        warn "Could not load ClamAV::Client";
+        $self->register_test('test_register');
+        $self->register_test('test_get_clamd');
+    };
+
+    $self->register_test('test_err_and_return');
+    $self->register_test('test_get_filename');
+    $self->register_test('test_set_permission');
+    $self->register_test('test_is_too_big');
+    $self->register_test('test_is_multipart');
+    $self->register_test('test_should_scan');
 }
 
 sub test_register {


### PR DESCRIPTION
replace with done_testing(), which provides the same "make sure to kvetch if tests fail to run" without requiring humans to do the bookkeeping.
