### PR TITLE
Prefer Geo::IP over GeoIP2

### DIFF
--- a/plugins/ident/geoip
+++ b/plugins/ident/geoip
@@ -182,7 +182,8 @@ sub load_geoip2 {
         return;
     }
 
-    $self->log(LOGINFO, "GeoIP2 loaded");
+    warn "Using GeoIP2."
+       . " ASN data is not currently available using the GeoIP2 module!\n";
 
     eval {
         $self->{_geoip2_city} = GeoIP2::Database::Reader->new(
@@ -308,22 +309,27 @@ sub open_geoip_db {
         next if !-f "$db_dir/$db.dat";
         $self->log(LOGINFO, "using db $db");
         $self->{_geoip_city} = Geo::IP->open("$db_dir/$db.dat");
+        last if $self->{_geoip_city};
     }
+    warn "Missing GeoIP City data!\n" if ! $self->{_geoip_city};
 
     if (-f "$db_dir/GeoIPASNum.dat") {
         $self->log(LOGINFO, "using GeoIPASNum");
         $self->{GeoIPASNum} = Geo::IP->open("$db_dir/GeoIPASNum.dat");
     }
+    warn "Missing GeoIP ASN data!\n" if ! $self->{GeoIPASNum};
 
     if (-f "$db_dir/GeoIPASNumv6.dat") {
         $self->log(LOGINFO, "using GeoIPASNumv6");
         $self->{GeoIPASNumv6} = Geo::IP->open("$db_dir/GeoIPASNumv6.dat");
+        warn "Missing GeoIP ASN IPV6 data!\n" if ! $self->{GeoIPASNum};
     }
 
     # can't think of a good reason to load country if city data is present
     if (!$self->{_geoip_city}) {
         $self->log(LOGDEBUG, "using default db");
         $self->{_geoip} = Geo::IP->new();    # loads default Country DB
+        warn "Missing GeoIP Country data!\n" if ! $self->{_geoip};
     }
 }
 

--- a/t/plugin_tests/ident/geoip
+++ b/t/plugin_tests/ident/geoip
@@ -11,14 +11,11 @@ sub register_tests {
 
     eval 'use GeoIP2::Database::Reader';
     if ( !$@ ) {
-        warn "using GeoIP2\n";
         $self->register_test('test_geoip2_lookup');
     }
 
     eval 'use Geo::IP';
     if ( !$@ ) {
-        warn "loaded Geo::IP\n";
-
         $self->register_test('test_geoip_lookup');
         $self->register_test('test_geoip_load_db');
         $self->register_test('test_geoip_init_cc');


### PR DESCRIPTION
GeoIP2 doesn't support ASN data yet, so...
- try to load Geo::IP first
- if GeoIP2 is loaded instead, warn about lack of ASN data
