### PR TITLE
Fix error checking for socket connections

### DIFF
--- a/plugins/ident/p0f
+++ b/plugins/ident/p0f
@@ -323,12 +323,9 @@ sub query_p0f_v3 {
     my $query = $self->get_v3_query() or return;
 
     # Open the connection to p0f
-    my $sock;
-    eval {
-        $sock = IO::Socket::UNIX->new(Peer => $p0f_socket, Type => SOCK_STREAM);
-    };
+    my $sock = IO::Socket::UNIX->new(Peer => $p0f_socket, Type => SOCK_STREAM);
     if (!$sock) {
-        $self->log(LOGERROR, "skip, could not open socket: $@");
+        $self->log(LOGERROR, "skip, could not open socket: $!");
         return;
     }
 


### PR DESCRIPTION
- IO::Socket::UNIX->new should never die, therefore...
- $@ is always undef when the eval exits, so...
- use $! instead

This re-applies the important part of #175 which was reverted in #178
