### PR TITLE
Silence some warnings when $p0f->{genre} is undefined

### DIFF
--- a/plugins/ident/p0f
+++ b/plugins/ident/p0f
@@ -216,14 +216,14 @@ sub rcpt_handler {
 
 sub check_genre {
     my ( $self, $rcpt ) = @_;
-    my $p0f = $self->connection->notes('p0f') or return 0;
+    my $genre = ( $self->connection->notes('p0f') || {} )->{genre} or return 0;
     return 0 if $self->exclude_connection();
     return 0 if $self->exclude_recipient($rcpt);
     for my $phrase ( @{ $self->{os_block} || [] } ) {
-        return 1 if $p0f->{genre} eq $phrase;
+        return 1 if $genre eq $phrase;
     }
     for my $re ( @{ $self->{os_block_re} || [] } ) {
-        return 1 if $p0f->{genre} =~ $re;
+        return 1 if $genre =~ $re;
     }
     return 0;
 }


### PR DESCRIPTION
This is meant to avoid warnings such as:

```
Dec 30 07:46:33 mail qpsmtpd[9726]: Use of uninitialized value in pattern match (m//) at /usr/share/qpsmtpd/plugins/ident/p0f line 226, <STDIN> line 3.
Dec 30 08:01:29 mail qpsmtpd[9722]: Use of uninitialized value in pattern match (m//) at  /usr/share/qpsmtpd/plugins/ident/p0f line 226, <STDIN> line 3.
Dec 30 08:01:29 mail qpsmtpd[10555]: Use of uninitialized value in pattern match (m//) at /usr/share/qpsmtpd/plugins/ident/p0f line 226.
Dec 30 08:01:59 mail qpsmtpd[10261]: Use of uninitialized value in pattern match (m//) at /usr/share/qpsmtpd/plugins/ident/p0f line 226, <STDIN> line 3.
Dec 30 08:04:55 mail qpsmtpd[10307]: Use of uninitialized value in pattern match (m//) at /usr/share/qpsmtpd/plugins/ident/p0f line 226, <STDIN> line 3.
```

It passes the test suite, but the tests for check_genre() are pretty sparse, so I'm not sure how much that tells us.
