### PR TITLE
Change Received header ordering when using SSL, to fix interaction problem with Spamassassin

### DIFF
--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -843,7 +843,7 @@ sub received_line {
         $smtp .= "S" if $esmtp;    # RFC3848
         $sslheader = "("
           . $self->connection->notes('tls_socket')->get_cipher()
-          . " encrypted) ";
+          . " encrypted)";
     }
     if (defined $self->{_auth} && $self->{_auth} == OK) {
         my $mech = $self->{_auth_mechanism};
@@ -869,7 +869,7 @@ sub received_line {
           . $self->config('me')
           . " (qpsmtpd/"
           . $self->version
-          . ") with $sslheader$smtp; "
+          . ") with $smtp $sslheader; "
           . (strftime('%a, %d %b %Y %H:%M:%S %z', localtime));
     }
     $self->transaction->header->add('Received', $header_str, 0);


### PR DESCRIPTION
If a client is using SSL, then Spamassassin won't be able to detect user authentication. This change will fix the problem.

Relevant code in Spamassassin source:

    if (/ by / && / with ((?:ES|L|UTF8S|UTF8L)MTPS?A|ASMTP|HTTPU?)(?: |;|$)/i) {

Basically if we insert comment between 'with' and 'ESMTPSA', then Spamassassin won't be able to tell if the session is authenticated.

Old Debian bug for reference: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=684571