### PR TITLE
Remove unnecessary calls to cleanup_and_return()

### DIFF
--- a/plugins/greylisting
+++ b/plugins/greylisting
@@ -437,7 +437,7 @@ sub convert_db {
     }
     $self->db->unlock;
     $self->log(LOGINFO, "converted $converted of $count DB entries");
-    return $self->cleanup_and_return(DECLINED);
+    return DECLINED;
 }
 
 sub prune_db {
@@ -456,7 +456,7 @@ sub prune_db {
     }
     $self->db->unlock;
     $self->log(LOGINFO, "pruned $pruned of $count DB entries");
-    return $self->cleanup_and_return(DECLINED);
+    return DECLINED;
 }
 
 sub exclude {


### PR DESCRIPTION
prune_db() and migrate_db() already call unlock(), calling
cleanup_and_return() only added a second (redundant) call to unlock()