### PR TITLE
Don't enforce tight parens with perltidy

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -2,7 +2,6 @@
 -i=4    # 4 space indentation (we used to use 2; in the future we'll use 4)
 -ci=2   # continuation indention
 
--pt=2   # tight parens
 -sbt=2  # tight square parens
 -bt=2   # tight curly braces
 -bbt=0  # open code block curly braces


### PR DESCRIPTION
Revert to default of -pt=1 rather than -pt=2:

> -bt,-pt,-sbt: Container tightness
> These are parameters for controlling the amount of space within containing
> parentheses, braces, and square brackets. The example below shows the effect
> of the three possible values, 0, 1, and 2, for the case of parentheses:
>
>  if ( ( my $len_tab = length( $tabstr ) ) > 0 ) {  # -pt=0
>  if ( ( my $len_tab = length($tabstr) ) > 0 ) {    # -pt=1 (default)
>  if ((my $len_tab = length($tabstr)) > 0) {        # -pt=2
> A value of 0 causes all parens to be padded on the inside with a space, and
> a value of 2 causes this never to happen. With a value of 1, spaces will be
> introduced if the item within is more than a single token.

.perltidyrc has explicit settings for tight braces and square brackets so this PR only affects actual parens.

The tight parens decision was made in 2005 when .perltidyrc was introduced - 2535e77

I tried pretty hard but couldn't find any previous discussion about this
decision, I'm not quite sure who supported it, who cared about it at all,
or who knew about it at all.

What I know is that I like pt=1 better. Nobody ever gets what they want
if they don't ask :)