### PR TITLE
No tight square brackets or curly braces

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -2,8 +2,6 @@
 -i=4    # 4 space indentation (we used to use 2; in the future we'll use 4)
 -ci=2   # continuation indention
 
--sbt=2  # tight square parens
--bt=2   # tight curly braces
 -bbt=0  # open code block curly braces
 
 -lp     # line up with parentheses


### PR DESCRIPTION
> Likewise, the parameter -sbt=n or --square-bracket-tightness=n controls the
> space within square brackets, as illustrated below.
>
>  $width = $col[ $j + $k ] - $col[ $j ];  # -sbt=0
>  $width = $col[ $j + $k ] - $col[$j];    # -sbt=1 (default)
>  $width = $col[$j + $k] - $col[$j];      # -sbt=2
> Curly braces which do not contain code blocks are controlled by the
> parameter -bt=n or --brace-tightness=n.
>
>  $obj->{ $parsed_sql->{ 'table' }[0] };    # -bt=0
>  $obj->{ $parsed_sql->{'table'}[0] };      # -bt=1 (default)
>  $obj->{$parsed_sql->{'table'}[0]};        # -bt=2

As with PR #201, I can't find any previous concensus on introducing this
and for myself, I prefer the default.

FTR I can't find anything else in .perltidyrc that I have any bones with :)