### PR TITLE
[RFC] tls: adding support of Perfect Forward Secrecy

### DIFF
--- a/plugins/tls
+++ b/plugins/tls
@@ -87,7 +87,7 @@ sub init {
         $self->log(LOGINFO,
                    "Cannot locate dhparam, possible DHE algorithms will be unavailable.");
         $self->log(LOGINFO,
-                   "The encryption strength will decline que to lack of Forward Secrecy.");
+                   "The encryption strength will decline due to lack of Forward Secrecy.");
     }
     $self->tls_cert($cert);
     $self->tls_key($key);

--- a/plugins/tls
+++ b/plugins/tls
@@ -94,7 +94,8 @@ sub init {
                                         SSL_key_file    => $self->tls_key,
                                         SSL_ca_file     => $self->tls_ca,
                                         SSL_cipher_list => $self->tls_ciphers,
-                                        SSL_server      => 1
+                                        SSL_server      => 1,
+                                        SSL_honor_cipher_order => 1
                                        )
       or die "Could not create SSL context: $!";
 
@@ -195,6 +196,7 @@ sub _convert_to_ssl {
                                        SSL_cipher_list => $self->tls_ciphers,
                                        SSL_server      => 1,
                                        SSL_reuse_ctx   => $self->ssl_context,
+                                       SSL_honor_cipher_order => 1
                                       )
           or die "Could not create SSL socket: $!";
 
@@ -295,6 +297,7 @@ sub upgrade_socket {
                 SSL_startHandshake => 0,
                 SSL_server         => 1,
                 SSL_reuse_ctx   => $sp->ssl_context,
+                SSL_honor_cipher_order => 1
             }
         )
         or die "Could not upgrade socket to SSL: $!";

--- a/plugins/tls
+++ b/plugins/tls
@@ -8,9 +8,9 @@ tls - plugin to support STARTTLS
 
 # in config/plugins
 
-tls [B<cert_path priv_key_path ca_path>]
+tls [B<cert_path priv_key_path ca_path dhparam_path>]
 
-=over 4
+=over 5
 
 =item B<cert_path>
 
@@ -23,6 +23,11 @@ Path to the private key file. Default: I<ssl/qpsmtpd-server.key>
 =item B<ca_path>
 
 Path to the certificate authority file. Default: I<ssl/qpsmtpd-ca.crt>
+
+=item B<dhparam_path>
+
+Path to the DH parameter file if you want Diffie-Hellman key exchange.
+Default: I<ssl/qpsmtpd-dhparam.pem>
 
 =back
 
@@ -66,19 +71,28 @@ use IO::Socket::SSL 0.98;
 use Qpsmtpd::Constants;
 
 sub init {
-    my ($self, $qp, $cert, $key, $ca) = @_;
+    my ($self, $qp, $cert, $key, $ca, $dhparam) = @_;
     my $dir = -d 'ssl' ? 'ssl' : 'config/ssl';
     $cert ||= "$dir/qpsmtpd-server.crt";
     $key  ||= "$dir/qpsmtpd-server.key";
     $ca   ||= "$dir/qpsmtpd-ca.crt";
+    $dhparam ||= "$dir/qpsmtpd-dhparam.pem";
     unless (-f $cert && -f $key && -f $ca) {
         $self->log(LOGERROR,
                    "Cannot locate cert/key!  Run plugins/tls_cert to generate");
         return;
     }
+    unless (-f $dhparam) {
+        $dhparam = "";
+        $self->log(LOGINFO,
+                   "Cannot locate dhparam, possible DHE algorithms will be unavailable.");
+        $self->log(LOGINFO,
+                   "The encryption strength will decline que to lack of Forward Secrecy.");
+    }
     $self->tls_cert($cert);
     $self->tls_key($key);
     $self->tls_ca($ca);
+    $self->tls_dhparam($dhparam);
     $self->tls_ciphers($self->qp->config('tls_ciphers') || 'HIGH');
 
     $self->log(LOGDEBUG, "ciphers: " . $self->tls_ciphers);
@@ -93,6 +107,7 @@ sub init {
                                         SSL_cert_file   => $self->tls_cert,
                                         SSL_key_file    => $self->tls_key,
                                         SSL_ca_file     => $self->tls_ca,
+					SSL_dh_file     => $self->tls_dhparam,
                                         SSL_cipher_list => $self->tls_ciphers,
                                         SSL_server      => 1,
                                         SSL_honor_cipher_order => 1
@@ -193,6 +208,7 @@ sub _convert_to_ssl {
                                        SSL_cert_file   => $self->tls_cert,
                                        SSL_key_file    => $self->tls_key,
                                        SSL_ca_file     => $self->tls_ca,
+				       SSL_dh_file     => $self->tls_dhparam,
                                        SSL_cipher_list => $self->tls_ciphers,
                                        SSL_server      => 1,
                                        SSL_reuse_ctx   => $self->ssl_context,
@@ -234,6 +250,12 @@ sub tls_ca {
     my $self = shift;
     @_ and $self->{_tls_ca} = shift;
     $self->{_tls_ca};
+}
+
+sub tls_dhparam {
+    my $self = shift;
+    @_ and $self->{_tls_dhparam} = shift;
+    $self->{_tls_dhparam};
 }
 
 sub tls_ciphers {
@@ -293,6 +315,7 @@ sub upgrade_socket {
                 SSL_cert_file   => $sp->tls_cert,
                 SSL_key_file    => $sp->tls_key,
                 SSL_ca_file     => $sp->tls_ca,
+                SSL_dh_file     => $self->tls_dhparam,
                 SSL_cipher_list => $sp->tls_ciphers,
                 SSL_startHandshake => 0,
                 SSL_server         => 1,

--- a/plugins/tls
+++ b/plugins/tls
@@ -82,10 +82,10 @@ sub init {
                    "Cannot locate cert/key!  Run plugins/tls_cert to generate");
         return;
     }
-    unless (-f $dhparam) {
-        $dhparam = "";
+    unless (-f $dhparam && -s $dhparam) {
+        $dhparam = undef;
         $self->log(LOGINFO,
-                   "Cannot locate dhparam, possible DHE algorithms will be unavailable.");
+                   "dhparam is not exist or empty, possible DHE ciphers will be unavailable.");
         $self->log(LOGINFO,
                    "The encryption strength will decline due to lack of Forward Secrecy.");
     }

--- a/plugins/tls
+++ b/plugins/tls
@@ -107,7 +107,7 @@ sub init {
                                         SSL_cert_file   => $self->tls_cert,
                                         SSL_key_file    => $self->tls_key,
                                         SSL_ca_file     => $self->tls_ca,
-					SSL_dh_file     => $self->tls_dhparam,
+                                        SSL_dh_file     => $self->tls_dhparam,
                                         SSL_cipher_list => $self->tls_ciphers,
                                         SSL_server      => 1,
                                         SSL_honor_cipher_order => 1
@@ -208,7 +208,7 @@ sub _convert_to_ssl {
                                        SSL_cert_file   => $self->tls_cert,
                                        SSL_key_file    => $self->tls_key,
                                        SSL_ca_file     => $self->tls_ca,
-				       SSL_dh_file     => $self->tls_dhparam,
+                                       SSL_dh_file     => $self->tls_dhparam,
                                        SSL_cipher_list => $self->tls_ciphers,
                                        SSL_server      => 1,
                                        SSL_reuse_ctx   => $self->ssl_context,

--- a/plugins/tls_cert
+++ b/plugins/tls_cert
@@ -95,7 +95,7 @@ system('openssl', 'x509', '-extfile', $SIGNfilename, '-days', (365*2),
 	'-req', '-out', $SERVER_crt) == 0
     or die "Cannot sign cert: $?";
 
-system('openssl', 'dhparam', '-out', '$SERVER_dhparam', 2048) == 0
+system('openssl', 'dhparam', '-out', $SERVER_dhparam, 2048) == 0
     or die "Cannot create server dhparam: $?";
 
 exit(0);

--- a/plugins/tls_cert
+++ b/plugins/tls_cert
@@ -62,6 +62,7 @@ system('openssl', 'req', '-config', $CAfilename, '-new', '-x509',
 my $SERVER_key = 'ssl/qpsmtpd-server.key';
 my $SERVER_csr = 'ssl/qpsmtpd-server.csr';
 my $SERVER_crt = 'ssl/qpsmtpd-server.crt';
+my $SERVER_dhparam = 'ssl/qpsmtpd-server.dhparam';
 
 my ($SERVER, $SERVERfilename) = tempfile( $template, DIR => "ssl", UNLINK => 1);
 print ${SERVER} return_cfg($opts{OU});
@@ -93,6 +94,9 @@ system('openssl', 'x509', '-extfile', $SIGNfilename, '-days', (365*2),
 	'-CAkey', $CA_key, '-in', $SERVER_csr,
 	'-req', '-out', $SERVER_crt) == 0
     or die "Cannot sign cert: $?";
+
+system('openssl', 'dhparam', '-out', '$SERVER_dhparam', 2048) == 0
+    or die "Cannot create server dhparam: $?";
 
 exit(0);
 	

--- a/plugins/tls_cert
+++ b/plugins/tls_cert
@@ -62,7 +62,7 @@ system('openssl', 'req', '-config', $CAfilename, '-new', '-x509',
 my $SERVER_key = 'ssl/qpsmtpd-server.key';
 my $SERVER_csr = 'ssl/qpsmtpd-server.csr';
 my $SERVER_crt = 'ssl/qpsmtpd-server.crt';
-my $SERVER_dhparam = 'ssl/qpsmtpd-server.dhparam';
+my $SERVER_dhparam = 'ssl/qpsmtpd-dhparam.pem';
 
 my ($SERVER, $SERVERfilename) = tempfile( $template, DIR => "ssl", UNLINK => 1);
 print ${SERVER} return_cfg($opts{OU});


### PR DESCRIPTION

> Even if you are offering Perfect Forward Secrecy, very few clients will take advantages. - Ladar Levison, Lavabit

That's no longer true, after the shutdown of Lavabit and the revelation from Edward Snowden. Today, more and more applications start supporting DHE based encryption to enable Perfect Forward Secrecy. The massive government surveillance told us a lesson, even using SSL/TLS and AES is not enough. If you lost your private key, captured traffic from any time period, can be easily decrypted.

It is worthy to support such important feature in the `tls` module. This patch allows `tls` accepts a parameter, `dhparam_path`, and allows `tls_cert` to generate `dhparam` file. But there are some issues to solve, that's why this is a RFC:

1. Does the connection work without issue if `SSL_dh_file` is empty?
2. What if DHE support of OpenSSL is disabled (often due to law issues) on the target host?
3. `tls` requires `IO::Socket::SSL` v0.98, which is a really old version. Should we keep backwards compatibility on hosts which really running such old `IO::Socket::SSL` or `OpenSSL`? And how?

Any comment are welcomed.