### PR TITLE
Fix FATAL PLUGIN ERROR [whitelist]:  Can't call method "can"...

### DIFF
--- a/lib/Qpsmtpd/Config.pm
+++ b/lib/Qpsmtpd/Config.pm
@@ -34,7 +34,7 @@ sub config {
 
     # first run the user_config hooks
     my ($rc, @config);
-    if (ref $type && $type->can('address')) {
+    if (ref $type && UNIVERSAL::can($type, 'address')) {
         ($rc, @config) = $qp->run_hooks_no_respond('user_config', $type, $c);
         if (defined $rc && $rc == OK) {
             return wantarray ? @config : $config[0];


### PR DESCRIPTION
... on unblessed reference at lib/Qpsmtpd/Config.pm line 38, <STDIN> line 1.

I keep getting this error message for each of whitelist's config files.