### PR TITLE
Fix XX: Can't call method "notes" on unblessed reference at /home/smtpd/...

### DIFF
--- a/plugins/logging/file
+++ b/plugins/logging/file
@@ -275,12 +275,13 @@ sub hook_logging {
     if (   !$self->{_f}
         || !$self->{_nosplit}
         || !$transaction
+        || !UNIVERSAL::can($transaction, 'notes')
         || !$transaction->notes('file-logged-this-session'))
     {
         unless (defined $self->maybe_reopen($transaction)) {
             return DECLINED;
         }
-        $transaction->notes('file-logged-this-session', 1) if $transaction;
+        $transaction->notes('file-logged-this-session', 1) if $transaction && UNIVERSAL::can($transaction, 'notes');
     }
 
     my $f = $self->{_f};


### PR DESCRIPTION
...qpsmtpd/plugins/logging/file line 275 and line 185.

I'm getting these error messages, too. This shuts them up, but I'm not sure whether the fix is correct. How can it be that we have a transaction without notes?