### PR TITLE
Fix XX: Can't call method "notes" on unblessed reference at /home/smtpd/...

### DIFF
--- a/plugins/logging/file
+++ b/plugins/logging/file
@@ -279,13 +279,14 @@ sub hook_logging {
     if (   !$self->{_f}
         || !$self->{_nosplit}
         || !$transaction
+        || !UNIVERSAL::can($transaction, 'notes')
         || !$transaction->notes('file-logged-this-session'))
     {
         unless (defined $self->maybe_reopen($transaction)) {
             return DECLINED;
         }
-        if (UNIVERSAL::can($transaction,'isa')) {
-            $transaction->notes('file-logged-this-session', 1) if $transaction;
+        if (UNIVERSAL::can($transaction,'isa') && $transaction && UNIVERSAL::can($transaction, 'notes')) {
+            $transaction->notes('file-logged-this-session', 1);
         }
     }
 


### PR DESCRIPTION
...qpsmtpd/plugins/logging/file line 282 and line 288.

Second try after https://github.com/smtpd/qpsmtpd/pull/225.

I refactored the _postfix if_ as requested, but it looks weird. If `UNIVERSAL::can($transaction,'isa')` is true, then `$transaction` is true, too, right? So, the original _postfix if_ was redundant?

Why do we check for `'isa'` anyway? Wouldn't the check for `'notes'` be sufficient?

And, if we don't have `notes`, shouldn't we add it? Could this explain why I'm seeing LOGDEBUG output from a single transaction spread over several files (with seconds in the file name)?
