### PR TITLE
Should only reject if host is not localhost but HELO claims to be one

### DIFF
--- a/plugins/helo
+++ b/plugins/helo
@@ -345,7 +345,7 @@ sub invalid_localhost {
         $self->log(LOGDEBUG, "pass, is localhost");
         return;
     }
-    if ($host && lc $host eq 'localhost') {
+    if ($host && lc $host ne 'localhost') {
         $self->log(LOGDEBUG, "pass, host is localhost");
         return;
     };


### PR DESCRIPTION
The helo plugin is supposed to reject if HELO is localhost but the email is not coming from localhost.

The last patch broke this and will reject everything unless IP is localhost or HELO is localhost.