### PR TITLE
check *every* regex, not just first

### DIFF
--- a/plugins/helo
+++ b/plugins/helo
@@ -307,7 +307,9 @@ sub is_in_badhelo {
     $host = lc $host;
     foreach my $bad ($self->qp->config('badhelo')) {
         if ($bad =~ /[\{\}\[\]\(\)\^\$\|\*\+\?\\\!]/) {    # it's a regexp
-            return $self->is_regex_match($host, $bad);
+            if ($self->is_regex_match($host, $bad)) {
+                return $error, "in badhelo";
+            }
         }
         if ($host eq lc $bad) {
             return $error, "in badhelo";

--- a/t/plugin_tests/helo
+++ b/t/plugin_tests/helo
@@ -56,11 +56,11 @@ sub test_invalid_localhost {
     foreach my $ip ( undef, '', '192.0.99.5' ) {
         $self->qp->connection->remote_ip(undef);
         ($err, $why) = $self->invalid_localhost('localhost' );
-        ok(!$err, "host: localhost, invalid remote ip");
+        ok($err, "host: localhost, remote ip ($ip)");
 
         $self->qp->connection->remote_ip(undef);
         ($err, $why) = $self->invalid_localhost('not-localhost');
-        ok($err, "host: not-localhost, invalid remote ip");
+        ok(! $err, "host: not-localhost, remote ip ($ip)");
     }
 
     foreach my $ip (qw/ ::1 127.0.0.1 / ) {


### PR DESCRIPTION
This corrects an issue raised by Chris Dallimore on the email list.

````
To: qpsmtpd@perl.org
From: Chris Dallimore <snip>
Subject: helo plugin fails to match badhelo

The helo plugin fails to match any entries in badhelo, as the is_regex_match sub returns after the first (usually unsuccessful) test.

This works for me:

--- a/plugins/helo
+++ b/plugins/helo
@@ -301,40 +301,27 @@

sub is_in_badhelo {
    my ($self, $host) = @_;
-
-    my $error = "I do not believe you are $host.";
+    my $error = "Your HELO hostname is not allowed";

    $host = lc $host;
    foreach my $bad ($self->qp->config('badhelo')) {
        if ($bad =~ /[\{\}\[\]\(\)\^\$\|\*\+\?\\\!]/) {    # it's a regexp
-            return $self->is_regex_match($host, $bad);
+            #$self->log( LOGDEBUG, "is regex ($bad)");
+            if (substr($bad, 0, 1) eq '!') {
+                $bad = substr $bad, 1;
+                if ($host !~ /$bad/) {
+                    #$self->log( LOGDEBUG, "matched negative pattern (\!$bad)");
+                    return $error, "badhelo negative pattern match (\!$bad)";
        }
-        if ($host eq lc $bad) {
-            return $error, "in badhelo";
        }
+            elsif ($host =~ /$bad/) {
+                #$self->log( LOGDEBUG, "matched ($bad)");
+                return $error, "badhelo pattern match ($bad)";
    }
-    return;
}
-
-sub is_regex_match {
-    my ($self, $host, $pattern) = @_;
-
-    my $error = "Your HELO hostname is not allowed";
-
-    #$self->log( LOGDEBUG, "is regex ($pattern)");
-    if (substr($pattern, 0, 1) eq '!') {
-        $pattern = substr $pattern, 1;
-        if ($host !~ /$pattern/) {
-
-            #$self->log( LOGDEBUG, "matched ($pattern)");
-            return $error, "badhelo pattern match ($pattern)";
+        elsif ($host eq lc $bad) {
+            return $error, "($bad) in badhelo";
        }
-        return;
-    }
-    if ($host =~ /$pattern/) {
-
-        #$self->log( LOGDEBUG, "matched ($pattern)");
-        return $error, "badhelo pattern match ($pattern)";
    }
    return;
}
````