### PR TITLE
Replace all occurances of CR in X-Spam-Status

### DIFF
--- a/plugins/spamassassin
+++ b/plugins/spamassassin
@@ -273,7 +273,7 @@ sub insert_spam_headers {
         if ($name eq 'X-Spam-Status') {
             $self->parse_spam_header($new_headers->{$name});
         }
-        $new_headers->{$name} =~ s/\015//;    # hack for outlook
+        $new_headers->{$name} =~ s/\015//g;    # hack for outlook
         $self->_cleanup_spam_header($transaction, $name);
         $transaction->header->add($name, $new_headers->{$name}, 0);
     }


### PR DESCRIPTION
The hack for outlook (replacing CR in X-Spam-Status header) assumes
that there is only a single occurance of CR. However, if spamassassin
adds some more spam status information X-Spam-Status might be several lines
long leading to multiple occurance of CR.
This fix changes the substitute to a global subsititute, replacing all
CRs in the X-SPam-Status header.