### PR TITLE
Prevent credentials being logged in plain text

### DIFF
--- a/lib/Qpsmtpd/TcpServer.pm
+++ b/lib/Qpsmtpd/TcpServer.pm
@@ -120,7 +120,10 @@ sub read_input {
     while (<STDIN>) {
         alarm 0;
         $_ =~ s/\r?\n$//s;                         # advanced chomp
-        $self->log(LOGINFO, "dispatching $_");
+        my $log = $_;
+        $log =~ s/AUTH PLAIN (.*)/AUTH PLAIN <hidden credentials>/
+          unless ($self->config('loglevel') || '6') >= 7;
+        $self->log(LOGINFO, "dispatching $log")
         $self->connection->notes('original_string', $_);
         defined $self->dispatch(split / +/, $_, 2)
           or $self->respond(502, "command unrecognized: '$_'");

--- a/lib/Qpsmtpd/TcpServer.pm
+++ b/lib/Qpsmtpd/TcpServer.pm
@@ -123,7 +123,7 @@ sub read_input {
         my $log = $_;
         $log =~ s/AUTH PLAIN (.*)/AUTH PLAIN <hidden credentials>/
           unless ($self->config('loglevel') || '6') >= 7;
-        $self->log(LOGINFO, "dispatching $log")
+        $self->log(LOGINFO, "dispatching $log");
         $self->connection->notes('original_string', $_);
         defined $self->dispatch(split / +/, $_, 2)
           or $self->respond(502, "command unrecognized: '$_'");


### PR DESCRIPTION
This patch prevent credentials being logged when using PLAIN AUTH (without, we can see a base64 encoded concatenation of the login and the password in the log). If you set the highest log level, you'll still get them if needed, but not when running in production (using a lower log level)