### PR TITLE
Prevent a "Use of implicit split" warning

### DIFF
--- a/plugins/helo
+++ b/plugins/helo
@@ -521,7 +521,8 @@ sub check_name_match {
     my ($dns_name, $helo_name) = @_;
 
     return if !$dns_name;
-    return if split(/\./, $dns_name) < 2;    # not a FQDN
+    my @dots = split(/\./, $dns_name);
+    return if scalar @dots < 2;    # not a FQDN
 
     if ($dns_name eq $helo_name) {
         $self->log(LOGDEBUG, "reverse name match");


### PR DESCRIPTION
In the helo plugin. Full warn is:
Use of implicit split to @_ is deprecated at /usr/share/qpsmtpd/plugins/helo line 524