### PR TITLE
Make spammy_tlds configurable

### DIFF
--- a/config.sample/karma_tlds
+++ b/config.sample/karma_tlds
@@ -1,14 +1,14 @@
 # Karma to apply depending on the tld of the envelope sender
 # Used by the karma plugin
-info:-4
-pw:-4
-tw:-3
-biz:-3
-cl:-2
-br:-2
-fr:-2
-be:-2
-jp:-2
-no:-2
-se:-2
-sg:-2
+# Warning: setting karma too low can blacklist the entire tld
+work:-4
+rocks:-3
+ninja:-3
+info:-2
+biz:-2
+pw:-2
+me:-1
+us:-5
+eu:-4
+link:-3
+science:-6

--- a/config.sample/karma_tlds
+++ b/config.sample/karma_tlds
@@ -1,0 +1,14 @@
+# Karma to apply depending on the tld of the envelope sender
+# Used by the karma plugin
+info:-4
+pw:-4
+tw:-3
+biz:-3
+cl:-2
+br:-2
+fr:-2
+be:-2
+jp:-2
+no:-2
+se:-2
+sg:-2

--- a/plugins/karma
+++ b/plugins/karma
@@ -92,6 +92,20 @@ following list will be used:
 
 Adjust the quantity of logging for this plugin. See docs/logging.pod
 
+=head1 CONFIG FILES
+
+This plugin uses the following configuration files. All are optional.
+
+=head2 karma_tlds
+
+This file can contain semicolon separated tlds and the corresponding
+karma adjustment to apply when the envelope sender match. It can be used to
+penalize "spammy" tlds, or to raise the karma from (mostly) good tlds.
+
+jp:-4
+ch:-3
+fr:+1
+
 =head1 BENEFITS
 
 Karma reduces the resources wasted by naughty mailers.  When used with
@@ -341,18 +355,14 @@ sub from_handler {
     my $full_from = $self->connection->notes('envelope_from');
     $self->illegal_envelope_format( $full_from );
 
-    my %spammy_tlds = (
-            map { $_ => 4 } qw/ info pw /,
-            map { $_ => 3 } qw/ tw biz /,
-            map { $_ => 2 } qw/ cl br fr be jp no se sg /,
-            );
-    foreach my $tld ( keys %spammy_tlds ) {
+    my $karma_tlds = $self->get_karma_tlds() or return DECLINED;
+    foreach my $tld ( keys %$karma_tlds ) {
         my $len = length $tld;
-        my $score = $spammy_tlds{$tld} or next;
+        my $score = $karma_tlds->{$tld} or next;
         $len ++;
         if ( $sender->host && ".$tld" eq substr($sender->host,-$len,$len) ) {
-            $self->log(LOGINFO, "penalizing .$tld envelope sender");
-            $self->adjust_karma(-$score);
+            $self->log(LOGINFO, "adjusting karma for .$tld envelope sender");
+            $self->adjust_karma($score);
         }
     }
 
@@ -466,6 +476,19 @@ sub illegal_envelope_format {
         $self->log(LOGINFO, "illegal envelope address format: $addr" );
         $self->adjust_karma(-2);
     }
+}
+
+sub get_karma_tlds {
+    my $self = shift;
+
+    my %karma_tlds =
+      map { (split /:/, $_, 2)[0, 1] } $self->qp->config('karma_tlds');
+    if (!%karma_tlds) {
+        $self->log(LOGDEBUG, "no specific karma for tlds defined");
+        return;
+    }
+
+    return \%karma_tlds;
 }
 
 sub parse_db_record {


### PR DESCRIPTION
The hardcoded list of spammy tlds can't fit every needs. Makes this configurable through a config file.
You can now also raise the karma for tlds you want.
The default config provided keep the same behaviour as before.