### PR TITLE
Check rua is defined before trying to parse it

### DIFF
--- a/plugins/dmarc
+++ b/plugins/dmarc
@@ -144,7 +144,7 @@ sub check_dmarc {
     my $pol;
     eval { $pol = $dmarc->result->published; };
     if ( $self->{_args}{reporting} && $pol ) {
-        if ( $dmarc->has_valid_reporting_uri($pol->rua) ) {
+        if ( $pol->rua && $dmarc->has_valid_reporting_uri($pol->rua) ) {
             eval { $dmarc->save_aggregate(); };
             $self->log(LOGERROR, $@ ) if $@;
         }


### PR DESCRIPTION
Because $pol->rua returns undef is there's no rua defined, an error is printed in the logs

FATAL PLUGIN ERROR [dmarc]:  URI string is required! at /usr/share/perl5/vendor_perl/Mail/DMARC/PurePerl.pm line 295