### PR TITLE
Check $addr is defined before using it

### DIFF
--- a/lib/Qpsmtpd.pm
+++ b/lib/Qpsmtpd.pm
@@ -448,7 +448,7 @@ sub auth_mechanism {
 sub address {
     my $self = shift;
     my $addr = Qpsmtpd::Address->new(@_);
-    $addr->qp($self);
+    $addr->qp($self) if $addr;
     return $addr;
 }
 


### PR DESCRIPTION
Prevent the following error if we receive an invalid RCPT TO (eg <"relaytest%nmap.scanme.org">)

Can't call method "qp" on an undefined value at /usr/share/perl5/vendor_perl/Qpsmtpd.pm line 451.
/usr/bin/qpsmtpd-forkserver[17472]: command 'rcpt' failed unexpectedly