### PR TITLE
Skip invalid hostnames check in uribl

### DIFF
--- a/plugins/uribl
+++ b/plugins/uribl
@@ -134,6 +134,11 @@ my %strict_twolevel_cctlds = (
                               'za' => 1,
                              );
 
+# A list of regex to match strings which could look like hostname, but are invalid
+my @invalid_hostname = (
+    qr{\.\.}ix
+);
+
 sub init {
     my ($self, $qp, %args) = @_;
 
@@ -351,6 +356,7 @@ sub lookup_start {
               )
         {
             my $host = lc $1;
+            next if ($host ~~ @invalid_hostname);
             my @host_domains = split /\./, $host;
             $self->log(LOGDEBUG, "uribl: matched 'www.' hostname $host");
 
@@ -396,6 +402,7 @@ sub lookup_start {
               )
         {
             my $host = lc $1;
+            next if ($host ~~ @invalid_hostname);
             my @host_domains = split /\./, $host;
             $self->log(LOGDEBUG, "uribl: matched full URI hostname $host");
 


### PR DESCRIPTION
For example the string my..my would be detected as a hostname and ends with a fatal plugin error

(data_post) uribl: URIBL: checking sub-host my..my
(data_post) uribl: URIBL: checking sub-host .my
FATAL PLUGIN ERROR [uribl]:  unexpected null domain label at /usr/lib64/perl5/vendor_perl/Net/DNS/Question.pm line 80

Instead of creating too complex regex, add a global regex list and skip entries which match one of them.

For now, only .. are skiped, but it'll be easy to add more if needed

Note that this smart match operator requires perl 5.10 or later
