### PR TITLE
Move DNSBL check after MAIL FROM to make AUTH available

### DIFF
--- a/plugins/dnsbl
+++ b/plugins/dnsbl
@@ -151,8 +151,8 @@ sub register {
     }
 }
 
-sub hook_connect {
-    my ($self, $transaction) = @_;
+sub hook_mail {
+    my ($self, $transaction, $sender) = @_;
 
     # perform RBLSMTPD checks to mimic DJB's rblsmtpd
     # RBLSMTPD being non-empty means it contains the failure message to return


### PR DESCRIPTION
If plugin is set to disconnect before login is available then all IP addresses with DNSBL record will not be able to send email even if they are proper users (traveling, shared ISPs IPs...)