### PR TITLE
Move DNSBL check after MAIL FROM to make AUTH available

### DIFF
--- a/plugins/dnsbl
+++ b/plugins/dnsbl
@@ -151,8 +151,8 @@ sub register {
     }
 }
 
-sub hook_connect {
-    my ($self, $transaction) = @_;
+sub hook_mail {
+    my ($self, $transaction, $sender) = @_;
 
     # perform RBLSMTPD checks to mimic DJB's rblsmtpd
     # RBLSMTPD being non-empty means it contains the failure message to return

--- a/t/plugin_tests/dnsbl
+++ b/t/plugin_tests/dnsbl
@@ -8,7 +8,7 @@ use Qpsmtpd::Constants;
 sub register_tests {
     my $self = shift;
 
-    $self->register_test('test_hook_connect');
+    $self->register_test('test_hook_mail');
     $self->register_test('test_ip_whitelisted');
     $self->register_test('test_is_set_rblsmtpd');
     $self->register_test('test_reject_type');
@@ -45,7 +45,7 @@ sub test_is_set_rblsmtpd {
     cmp_ok( 1,'==',$self->is_set_rblsmtpd('10.1.1.1'), "empty");
 }
 
-sub test_hook_connect {
+sub test_hook_mail {
     my $self = shift;
 
     # reset values that other tests may have fiddled with
@@ -56,7 +56,7 @@ sub test_hook_connect {
     $conn->notes('naughty', undef);
     $conn->remote_ip('127.0.0.2'); # standard dnsbl test value
 
-    my ($rc, $mess) = $self->hook_connect($self->qp->transaction);
+    my ($rc, $mess) = $self->hook_mail($self->qp->transaction, "");
     if ( $rc == DENY ) {
         cmp_ok( $rc, '==', DENY, "connect +");
     }


### PR DESCRIPTION
If plugin is set to disconnect before login is available then all IP addresses with DNSBL record will not be able to send email even if they are proper users (traveling, shared ISPs IPs...)
