### PR TITLE
Fix Can't call method 'notes' on unblessed reference in plugins/logging/file.

### DIFF
--- a/plugins/logging/file
+++ b/plugins/logging/file
@@ -279,6 +279,7 @@ sub hook_logging {
     if (   !$self->{_f}
         || !$self->{_nosplit}
         || !$transaction
+        || !UNIVERSAL::can($transaction, 'notes')
         || !$transaction->notes('file-logged-this-session'))
     {
         unless (defined $self->maybe_reopen($transaction)) {


### PR DESCRIPTION
I still get a

FATAL PLUGIN ERROR [logging::file_3a7]: Can't call method "notes" on unblessed reference at /home/smtpd/qpsmtpd/plugins/logging/file line 279.

message from the current HEAD. This patch fixes it.