### PR TITLE
tls: fix a typo in SSL_dh_file.

### DIFF
--- a/plugins/tls
+++ b/plugins/tls
@@ -329,7 +329,7 @@ sub upgrade_socket {
                 SSL_cert_file   => $sp->tls_cert,
                 SSL_key_file    => $sp->tls_key,
                 SSL_ca_file     => $sp->tls_ca,
-                SSL_dh_file     => $self->tls_dhparam,
+                SSL_dh_file     => $sp->tls_dhparam,
                 SSL_cipher_list => $sp->tls_ciphers,
                 SSL_startHandshake => 0,
                 SSL_server         => 1,


### PR DESCRIPTION
In d5954ce249646f20151d40a4aaee0eafdca255af, dhparam has been added
to the tls plugin. But a typo was made, misspelled "sp" as "self".
This commit corrects this typo.

Signed-off-by: Tom Li <biergaizi@member.fsf.org>