### PR TITLE
Support for spamassassin userprefs - reject threshold

### DIFF
--- a/plugins/spamassassin
+++ b/plugins/spamassassin
@@ -32,7 +32,7 @@ the options.  Confused yet?  :-)  It looks like this in practice:
 
 =over 4
 
-=item reject [threshold]
+=item reject [threshold|userprefs]
 
 Set the threshold where the plugin will reject the mail.  Some
 mail servers are so useless that they ignore 55x responses not coming
@@ -41,6 +41,10 @@ retrying until the mail expires from their queue.
 
 Depending on your spamassassin configuration a reasonable setting is
 typically somewhere between 12 to 20.
+
+By setting reject = userprefs, the required threshold will be taken
+from spamassassin userprefs. Usually used in conjunction with
+spamd_user = vpopmail.
 
 The default is to never reject mail based on the SpamAssassin score.
 
@@ -424,6 +428,13 @@ sub reject {
         return DECLINED;
     };
 
+    if ($reject eq 'userprefs') {
+        $reject = $sa_results->{required} or do {
+            $self->log(LOGERROR, "error, reject disabled ($status, $learn)");
+            return DECLINED;
+        };
+    }
+    
     if ($score < $reject) {
         if ($ham_or_spam eq 'Spam') {
             $self->log(LOGINFO, "fail, tolerated, $status < $reject, $learn");


### PR DESCRIPTION
This change implements so if the 'reject' argument is set to the string 'userprefs' instead of a decimal value, the required threashold value will be taken from spamassassin userprefs required_score instead of set to a static value. This allows a per-user based threshold value.