### PR TITLE
Remove check $loginAs vs $user

### DIFF
--- a/lib/Qpsmtpd/Auth.pm
+++ b/lib/Qpsmtpd/Auth.pm
@@ -104,12 +104,6 @@ sub get_auth_details_plain {
         return;
     }
 
-    # Authorization ID must not be different from Authentication ID
-    if ($loginas ne '' && $loginas ne $user) {
-        $session->respond(535, "Authentication invalid for $user");
-        return;
-    }
-
     return $loginas, $user, $passClear;
 }
 


### PR DESCRIPTION
Is there any reasoning about this code? I have hit that when trying to setup qpsmtpd as smarthost and smtp client honestly set loginAs email address from "Mail From" header which obviously is not same as $user.

I am bit strugling with this, imho Qpsmtpd core should not decide if client is authorized if loginAs != user. Also this check can't be switched off nor customized via plugin.