### PR TITLE
Change GeoIP order

### DIFF
--- a/plugins/ident/geoip
+++ b/plugins/ident/geoip
@@ -145,8 +145,8 @@ sub register {
 
 sub load_geoip {
     my ( $self ) = @_;
-    $self->load_geoip1() and return 1;
     $self->load_geoip2() and return 1;
+    $self->load_geoip1() and return 1;
     return 0;
 }
 


### PR DESCRIPTION
Makes plugin try the more accurate GeoIP v2 before v1 (fallback).
Fixes #289