### PR TITLE
Adding IP address to logs for 535 LOGIN errors, to use with fail2ban

### DIFF
--- a/lib/Qpsmtpd/Auth.pm
+++ b/lib/Qpsmtpd/Auth.pm
@@ -76,7 +76,7 @@ sub SASL {
     else {
         $msg =
             uc($mechanism)
-          . " authentication failed for $user"
+          . " authentication failed for $user from $ENV{TCPREMOTEIP}"
           . ($msg ? " - $msg" : '');
         $session->respond(535, $msg);
         $session->log(LOGDEBUG, $msg);    # already logged by $session->respond


### PR DESCRIPTION
Based on the idea and patch linked from here: https://www.linkedin.com/pulse/howto-add-fail2ban-support-qpsmtpd-authentication-failures-andrew-pam/

Basically, just add the IP address to the log for other tools (in my case fail2ban) to parse and ban IPs that fail to authenticate.

This is ever so slightly different, as the link above is 5 years old. I tried this out directly against 0.94-4 in Debian Buster, then replicated the one-line change against current master.