### PR TITLE
Use readable file test for certificate files

### DIFF
--- a/plugins/tls
+++ b/plugins/tls
@@ -85,7 +85,7 @@ sub init {
     $key  ||= "$dir/qpsmtpd-server.key";
     $ca   ||= "$dir/qpsmtpd-ca.crt";
     $dhparam ||= "$dir/qpsmtpd-dhparam.pem";
-    unless (-f $cert && -f $key && -f $ca) {
+    unless (-r $cert && -r $key && -r $ca) {
         $self->log(LOGERROR,
                    "Cannot locate cert/key!  Run plugins/tls_cert to generate");
         return;


### PR DESCRIPTION
To make it easier to use Letsencrypt certificates with the tls plugin, I'd just like to propose to change the file test operators to `-r` as proposed in [this comment](https://community.letsencrypt.org/t/how-do-i-use-lets-encrypt-certs-in-qpsmtpd/142370/4).