### PR TITLE
Load plugins in qpsmtpd-forkserver at startup again

### DIFF
--- a/qpsmtpd-forkserver
+++ b/qpsmtpd-forkserver
@@ -193,7 +193,7 @@ POSIX::setgid($qgid) or die "unable to change gid: $!\n";
 POSIX::setuid($quid) or die "unable to change uid: $!\n";
 $> = $quid;
 
-#$qpsmtpd->load_plugins;
+$qpsmtpd->load_plugins;
 
 foreach my $addr (@LISTENADDR) {
     ::log(LOGINFO, "Listening on $addr->{addr}:$addr->{port}");


### PR DESCRIPTION
Removes the comment from line 196, which enables the loading of plugins at startup again. Otherwise there would have been the need for a SIGHUP in order to load the plugins initially.

Closes #308 and #288.