### PR TITLE
Fix received_line hook behaviour

### DIFF
--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -860,8 +860,8 @@ sub received_line {
     my $header_str;
     my ($rc, @received) =
       $self->run_hooks("received_line", $smtp, $authheader, $sslheader);
-    if ($rc == OK) {
-        return join("\n", @received);
+    if ($rc == OK) {        
+        $header_str = join("\n", @received);
     }
     else {    # assume $rc == DECLINED
         $header_str =


### PR DESCRIPTION
As specified in issue #309 there was a bug when using the received_line hook.

When the received_line hook returned a result, the calling method returned the new line instead of adding it to the header (see Debian bug #933679)

Closes #309