### PR TITLE
Extend barelf check to whole message

### DIFF
--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -681,20 +681,20 @@ sub data_respond {
 
     my $timeout = $self->config('timeout');
     while (defined($_ = $self->getline($timeout))) {
+        # Reject messages that have either bare LF or CR. rjkaes noticed a
+        # lot of spam that is malformed in the header.
+
+        if ($_ !~ /\r\n$/) {
+            $self->respond(421, 'See http://smtpd.develooper.com/barelf.html');
+            $self->disconnect;
+            return 1;
+        }
+
         if ($_ eq ".\r\n") {
             $complete++;
             $_ = '';
         }
         $i++;
-
-        # Reject messages that have either bare LF or CR. rjkaes noticed a
-        # lot of spam that is malformed in the header.
-
-        if ($_ eq ".\n" || $_ eq ".\r") {
-            $self->respond(421, 'See http://smtpd.develooper.com/barelf.html');
-            $self->disconnect;
-            return 1;
-        }
 
         unless (($max_size and $size > $max_size)) {
             s/\r\n$/\n/;

--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -681,6 +681,12 @@ sub data_respond {
 
     my $timeout = $self->config('timeout');
     while (defined($_ = $self->getline($timeout))) {
+        if ($_ eq ".\r\n") {
+            $complete++;
+            $_ = '';
+        }
+        $i++;
+
         # Reject messages that have either bare LF or CR. rjkaes noticed a
         # lot of spam that is malformed in the header.
 
@@ -689,12 +695,6 @@ sub data_respond {
             $self->disconnect;
             return 1;
         }
-
-        if ($_ eq ".\r\n") {
-            $complete++;
-            $_ = '';
-        }
-        $i++;
 
         unless (($max_size and $size > $max_size)) {
             s/\r\n$/\n/;


### PR DESCRIPTION
Instead of checking for bare LF just on end of message, check every line. This helps to mitigate SMTP smuggling.

Fixes #317