### PR TITLE
postfix: avoid logging full headers

### DIFF
--- a/lib/Qpsmtpd/Postfix.pm
+++ b/lib/Qpsmtpd/Postfix.pm
@@ -206,7 +206,7 @@ sub inject_mail {
 
     my $hdr = $transaction->header->as_string;
     for (split(/\r?\n/, $hdr)) {
-        print STDERR "hdr: $_\n";
+        # print STDERR "hdr: $_\n";
         $strm->print_msg_line($_);
     }
     $transaction->body_resetpos;


### PR DESCRIPTION
When the postfix queue plugin was added in 5abf363 (Added Postfix queue plugin thanks to Peter J Holzer!, 2004-02-19), some leftover debugging seems to have been included.

The 'print STDERR "hdr: $_\n";' line causes the full headers of every message to be logged.  A few lines below, a similar statement for the body lines is commented out.  Do the same for the header statement.