### PR TITLE
Move Authentication-Results to transaction

### DIFF
--- a/lib/Qpsmtpd/Plugin.pm
+++ b/lib/Qpsmtpd/Plugin.pm
@@ -270,13 +270,13 @@ sub store_deferred_reject {
 
 sub store_auth_results {
     my ($self, $result) = @_;
-    my $auths = $self->qp->connection->notes('authentication_results') or do {
-        $self->qp->connection->notes('authentication_results', $result);
+    my $auths = $self->qp->transaction->notes('authentication_results') or do {
+        $self->qp->transaction->notes('authentication_results', $result);
         return;
     };
     my $ar = join('; ', $auths, $result);
     $self->log(LOGDEBUG, "auth-results: $ar");
-    $self->qp->connection->notes('authentication_results', $ar);
+    $self->qp->transaction->notes('authentication_results', $ar);
 }
 
 sub is_immune {

--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -793,8 +793,8 @@ sub authentication_results {
     }
 
     # RFC 5451: used in AUTH, DKIM, DOMAINKEYS, SENDERID, SPF
-    if ($self->connection->notes('authentication_results')) {
-        push @auth_list, $self->connection->notes('authentication_results');
+    if ($self->transaction->notes('authentication_results')) {
+        push @auth_list, $self->transaction->notes('authentication_results');
     }
 
     $self->log(LOGDEBUG, "adding auth results header");


### PR DESCRIPTION
The authentication results from SPF/DKIM/etc. are part of a single message transaction, not the whole SMTP connection.  Without this change, when multiple messages are received during a single SMTP connection, the SPF/DKIM/etc. results just keep getting appended to an Authentication-Results header.