### PR TITLE
Allow an alternate ID for Authentication-Results

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -31,6 +31,12 @@ are shown below in ["Plugin settings"](#plugin-settings).
     the _Received: _header, ...
     Default is whatever Sys::Hostname's hostname() returns.
 
+- ar-me
+
+    Sets the ID string used in Authentication-Results: header (useful
+    for multi-server clusters).
+    Default is the same as me above.
+
 - plugin\_dirs
 
     Where to search for plugins (one directory per line), defaults to `./plugins`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,10 +31,11 @@ are shown below in ["Plugin settings"](#plugin-settings).
     the _Received: _header, ...
     Default is whatever Sys::Hostname's hostname() returns.
 
-- ar-me
+- me-auth-results
 
     Sets the ID string used in Authentication-Results: header (useful
-    for multi-server clusters).
+    for multi-server clusters). If this is set to "none", no
+    Authentication-Results: header will be added or modifed.
     Default is the same as me above.
 
 - plugin\_dirs

--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -776,7 +776,14 @@ sub data_respond {
 sub authentication_results {
     my ($self) = @_;
 
-    my @auth_list = $self->config('ar-me') // $self->config('me');
+    # don't add an Authentication-Results if this is "none"
+    my @auth_list = $self->config('me-auth-results');
+    if (! $auth_list[0]) {
+        @auth_list = $self->config('me');
+    }
+    elsif ($auth_list[0] eq "none") {
+        return;
+    }
 
     if (!defined $self->{_auth}) {
         push @auth_list, 'auth=none';
@@ -804,6 +811,10 @@ sub authentication_results {
 
 sub clean_authentication_results {
     my $self = shift;
+
+    # don't change any Authentication-Results if this is "none"
+    my ($auth_id) = $self->config('me-auth-results');
+    return if ($auth_id && ($auth_id eq "none"));
 
     # On messages received from the internet, move Authentication-Results headers
     # to Original-AR, so our downstream can trust the A-R header we insert.

--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -776,7 +776,7 @@ sub data_respond {
 sub authentication_results {
     my ($self) = @_;
 
-    my @auth_list = $self->config('me');
+    my @auth_list = $self->config('ar-me') // $self->config('me');
 
     if (!defined $self->{_auth}) {
         push @auth_list, 'auth=none';


### PR DESCRIPTION
When using a cluster of servers, it's sometimes needed to have the same ID in the Authentication-Results header, rather than just the hostname, and you don't always want to change "me" (because that has other effects).  Allow an alternate "ar-me" config file.