### PR TITLE
test: add barelf check

### DIFF
--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -682,7 +682,6 @@ sub data_respond {
     my $timeout = $self->config('timeout');
     while (defined($_ = $self->getline($timeout))) {
 
-        # Reject messages with a bare LF or CR, mitigates SMTP smuggling
         if ($_ !~ /\r\n$/) {
             $self->respond(421, 'See http://smtpd.develooper.com/barelf.html');
             $self->disconnect;

--- a/lib/Qpsmtpd/SMTP.pm
+++ b/lib/Qpsmtpd/SMTP.pm
@@ -681,20 +681,19 @@ sub data_respond {
 
     my $timeout = $self->config('timeout');
     while (defined($_ = $self->getline($timeout))) {
-        if ($_ eq ".\r\n") {
-            $complete++;
-            $_ = '';
-        }
-        $i++;
 
-        # Reject messages that have either bare LF or CR. rjkaes noticed a
-        # lot of spam that is malformed in the header.
-
+        # Reject messages with a bare LF or CR, mitigates SMTP smuggling
         if ($_ !~ /\r\n$/) {
             $self->respond(421, 'See http://smtpd.develooper.com/barelf.html');
             $self->disconnect;
             return 1;
         }
+
+        if ($_ eq ".\r\n") {
+            $complete++;
+            $_ = '';
+        }
+        $i++;
 
         unless (($max_size and $size > $max_size)) {
             s/\r\n$/\n/;

--- a/t/Test/Qpsmtpd.pm
+++ b/t/Test/Qpsmtpd.pm
@@ -69,6 +69,21 @@ sub command {
     $self->response;
 }
 
+sub mock_data {
+    # Queue message lines for getline() to feed to data_respond(). Accepts an
+    # arrayref of pre-split lines (each keeping its own terminator, so bare
+    # LF/CR lines can be injected) or a string split on LF.
+    my ($self, $data) = @_;
+    $self->{_mock_lines} =
+      ref $data eq 'ARRAY' ? [@$data] : [$data =~ /(.*?\n|.+)/gs];
+}
+
+sub getline {
+    my $self = shift;
+    return $self->SUPER::getline(@_) if !$self->{_mock_lines};
+    return shift @{$self->{_mock_lines}};    # undef once exhausted => EOF
+}
+
 sub input {
     my ($self, $command) = @_;
 

--- a/t/qpsmtpd-smtp.t
+++ b/t/qpsmtpd-smtp.t
@@ -155,12 +155,40 @@ sub __data_respond {
         'data_respond(DECLINED) response - no recips' );
     $smtpd->transaction->add_recipient(Qpsmtpd::Address->new('recip@example.com'));
 
-    # data_respond also runs the data_post hooks, so this will require a bit
-    # more work to get under test. we also don't yet have a way to mock
-    # message data; that will probably require overriding getline()
-    #$smtpd->mock_data( _test_message() );
-    #$smtpd->mock_hook( data_post => sub { return DECLINED } );
-    #is( $smtpd->data_respond(DECLINED), 1, 'data_respond, DECLINED' );
+    __data_respond_barelf();
+}
+
+sub __data_respond_barelf {
+    # A well-formed message must not be rejected as bare-LF; a bare LF/CR on
+    # any line must be.
+    my $drive = sub {
+        my @lines = @_;
+        ( $smtpd ) = Test::Qpsmtpd->new_conn();
+        $smtpd->transaction->sender(Qpsmtpd::Address->new('sender@example.com'));
+        $smtpd->transaction->add_recipient(Qpsmtpd::Address->new('recip@example.com'));
+        $smtpd->connection->notes( disconnected => 0 );
+        $smtpd->mock_data( [@lines] );
+
+        # Neutralize the data_* hooks so the barelf check in the DATA loop is
+        # exercised in isolation from the configured plugins.
+        no warnings 'redefine';
+        local *Qpsmtpd::run_hooks = sub { return (DECLINED, '') };
+        $smtpd->data_respond(DECLINED);
+        return ($smtpd->response)[0];
+    };
+
+    my $code = $drive->("From: a\@example.com\r\n", "Date: now\r\n", "\r\n", "body\r\n", ".\r\n");
+    isnt( $code, 421, 'well-formed message is not rejected as bare-LF' );
+    isnt( $smtpd->connection->notes('disconnected'), 1,
+        'well-formed message does not disconnect' );
+
+    $code = $drive->("From: a\@example.com\r\n", "bare\n", ".\r\n");
+    is( $code, 421, 'bare LF in body is rejected' );
+    is( $smtpd->connection->notes('disconnected'), 1, 'bare LF in body disconnects' );
+
+    $code = $drive->("From: a\@example.com\r\n", "\r\n", "body\r\n", ".\n");
+    is( $code, 421, 'bare LF terminator is rejected' );
+    is( $smtpd->connection->notes('disconnected'), 1, 'bare LF terminator disconnects' );
 }
 
 sub __clean_authentication_results {


### PR DESCRIPTION
## Tests

The existing `data_respond` test noted that exercising the DATA body "will probably require overriding `getline()`". This adds that: `mock_data()` in `Test::Qpsmtpd` queues lines for a mocked `getline`. New assertions in `t/qpsmtpd-smtp.t`:

- well-formed message → **not** rejected (fails on current master, passes with this fix)
- bare LF in the body → 421 + disconnect
- bare-LF terminator (`.\n`) → 421 + disconnect

Verified the well-formed test fails against the merged ordering and passes with the fix; smuggling-rejection tests pass either way. Full suite: 763 tests pass.
