### PR TITLE
naughty: check is_immune before reject

### DIFF
--- a/plugins/karma
+++ b/plugins/karma
@@ -16,6 +16,12 @@ senders. After sending a naughty message, if a sender has more naughty than
 nice connections, they are penalized for I<penalty_days>. Connections
 from senders in the penalty box are rejected per the settings in I<reject>.
 
+Karma keeps no verdict of its own. A connection is counted as naughty when
+another plugin drives its karma below I<-strikes> (see B<USING KARMA IN OTHER
+PLUGINS>) or flags it via the B<naughty> plugin, and nice when karma rises to
+I<strikes> or above. With no such plugins configured, karma has nothing to
+record and the naughty/nice counts stay empty.
+
 Karma provides other plugins with a karma value they can use to be more
 lenient, strict, or skip processing entirely.
 
@@ -436,21 +442,28 @@ sub data_handler {
 sub disconnect_handler {
     my $self = shift;
 
-    my $karma = $self->connection->notes('karma') or do {
+    return DECLINED if $self->is_immune();
+
+    my $karma   = $self->connection->notes('karma') || 0;
+    my $naughty_conn = $self->is_naughty();
+
+    # only record a verdict when a plugin adjusted karma or flagged the
+    # connection naughty; an untouched (neutral) connection has nothing to store
+    if (!$karma && !$naughty_conn) {
         $self->log(LOGDEBUG, "no karma");
         return DECLINED;
-    };
+    }
 
     $self->db->lock or return DECLINED;
     my $key  = $self->get_karma_key();
 
     my ($penalty_start_ts, $naughty, $nice, $connects) =
       $self->parse_db_record( $self->db->get($key) );
-    my $history = ($nice || 0) - $naughty;
     my $log_mess = '';
 
-    if ($karma <= -$self->{_args}{strikes}) {    # Enough negative strikes ?
-        $history--;
+    if ($karma <= -$self->{_args}{strikes} || $naughty_conn) {
+        $naughty++;
+        my $history = ($nice || 0) - $naughty;
         my $negative_limit = 0 - $self->{_args}{negative};
         if ($history <= $negative_limit) {
             if ($nice == 0 && $history < -5) {
@@ -473,6 +486,7 @@ sub disconnect_handler {
     else {
         $log_mess = "neutral";
     }
+    my $history = ($nice || 0) - $naughty;
     $self->log(LOGINFO, $log_mess . ", (msg: $karma, his: $history)");
 
     $self->db->set( $key, join(':', $penalty_start_ts, $naughty, $nice, ++$connects) );

--- a/plugins/naughty
+++ b/plugins/naughty
@@ -133,6 +133,13 @@ sub register {
 
 sub naughty {
     my $self = shift;
+
+    # An async whitelist (e.g. dns_whitelist_soft) may not set its note until
+    # rcpt, after the naughty flag was set at connect. Re-check immunity here,
+    # at disposal time, so a whitelisted host is not disconnected. Requires
+    # this hook to run after the whitelist's rcpt hook: use 'reject data'.
+    return DECLINED if $self->is_immune();
+
     my $naughty = $self->connection->notes('naughty') or do {
         $self->log(LOGINFO, 'pass');
         return DECLINED;

--- a/t/config/plugins
+++ b/t/config/plugins
@@ -63,6 +63,10 @@ auth/authdeny
 # this plugin needs to run after all other "rcpt" plugins
 rcpt_ok
 
+# dispose of naughty connections; 'reject data' runs after rcpt so an async
+# whitelist (dns_whitelist_soft) has set its note before disposal
+naughty reject data
+
 headers days 5 reject_type temp require From,Date
 #domainkeys
 dkim

--- a/t/config/plugins
+++ b/t/config/plugins
@@ -41,6 +41,8 @@ quit_fortune
 count_unrecognized_commands 4
 relay
 
+karma db_dir ./t/tmp
+
 resolvable_fromhost
 
 rhsbl

--- a/t/plugin_tests/karma
+++ b/t/plugin_tests/karma
@@ -1,0 +1,84 @@
+#!perl -w
+
+use strict;
+use warnings;
+
+use Qpsmtpd::Constants;
+
+sub register_tests {
+    my $self = shift;
+
+    $self->register_test('test_disconnect_records_naughty');
+    $self->register_test('test_disconnect_flagged_naughty');
+    $self->register_test('test_disconnect_records_nice');
+    $self->register_test('test_disconnect_skips_immune');
+}
+
+sub _fresh {
+    my ($self, $ip) = @_;
+
+    delete $self->{db};
+    $self->db( class => 'Qpsmtpd::DB::File::DBM', dir => 't/tmp' );
+
+    my $conn = $self->qp->connection;
+    $conn->relay_client(0);
+    $conn->notes($_, undef) for qw( whitelisthost naughty karma );
+    $conn->remote_ip($ip);
+    $self->qp->transaction->notes('whitelistsender', undef);
+
+    my $key = $self->get_karma_key($ip);
+    $self->db->lock;
+    $self->db->set($key, '0:0:0:0');
+    $self->db->unlock;
+    return $key;
+}
+
+sub _record {
+    my ($self, $key) = @_;
+    $self->db->lock;
+    my @rec = $self->parse_db_record( $self->db->get($key) );
+    $self->db->unlock;
+    return @rec;
+}
+
+sub test_disconnect_records_naughty {
+    my $self = shift;
+    my $key = $self->_fresh('192.0.2.11');
+    $self->connection->notes('karma', -3);    # <= -strikes
+    $self->disconnect_handler;
+    my (undef, $naughty) = $self->_record($key);
+    cmp_ok( $naughty, '==', 1, "negative karma increments the naughty count" );
+}
+
+sub test_disconnect_flagged_naughty {
+    my $self = shift;
+    my $key = $self->_fresh('192.0.2.12');
+    $self->is_naughty(1);                      # flagged, karma left neutral
+    $self->disconnect_handler;
+    my (undef, $naughty) = $self->_record($key);
+    cmp_ok( $naughty, '==', 1,
+        "naughty-flagged connection is counted despite neutral karma" );
+}
+
+sub test_disconnect_records_nice {
+    my $self = shift;
+    my $key = $self->_fresh('192.0.2.13');
+    $self->connection->notes('karma', 3);      # >= strikes
+    $self->disconnect_handler;
+    my (undef, $naughty, $nice) = $self->_record($key);
+    cmp_ok( $nice, '==', 1, "positive karma increments the nice count" );
+}
+
+sub test_disconnect_skips_immune {
+    my $self = shift;
+    my $key = $self->_fresh('192.0.2.14');
+    $self->connection->notes('karma', -3);
+    $self->connection->notes('whitelisthost', 'trusted');   # immune
+    $self->disconnect_handler;
+    my (undef, $naughty) = $self->_record($key);
+    cmp_ok( $naughty, '==', 0,
+        "immune (whitelisted) connection is not recorded" );
+
+    # don't leak immunity onto the shared connection used by later plugin tests
+    $self->connection->notes($_, undef) for qw( whitelisthost naughty karma );
+}

--- a/t/plugin_tests/naughty
+++ b/t/plugin_tests/naughty
@@ -1,0 +1,45 @@
+#!perl -w
+
+use strict;
+use warnings;
+
+use Qpsmtpd::Constants;
+
+sub register_tests {
+    my $self = shift;
+
+    $self->register_test('test_naughty');
+}
+
+sub _reset {
+    my $self = shift;
+    my $conn = $self->qp->connection;
+    $conn->relay_client(0);
+    $conn->notes('whitelisthost',   undef);
+    $conn->notes('naughty',         undef);
+    $self->qp->transaction->notes('whitelistsender', undef);
+}
+
+sub test_naughty {
+    my $self = shift;
+
+    $self->_reset;
+    cmp_ok( ($self->naughty)[0], '==', DECLINED,
+        "not flagged naughty => DECLINED" );
+
+    $self->_reset;
+    $self->connection->notes('naughty', 'go away');
+    my ($rc, $mess) = $self->naughty;
+    cmp_ok( $rc,   '==', DENY_DISCONNECT, "flagged naughty => disconnect" );
+    cmp_ok( $mess, 'eq', 'go away',       "naughty message returned" );
+
+    # #203: a host flagged naughty at connect but whitelisted at rcpt (e.g. by
+    # dns_whitelist_soft) must not be disconnected at disposal time.
+    $self->_reset;
+    $self->connection->notes('naughty', 'go away');
+    $self->connection->notes('whitelisthost', 'listed at dnswl.org');
+    cmp_ok( ($self->naughty)[0], '==', DECLINED,
+        "whitelisted host is not disconnected despite naughty flag" );
+
+    $self->_reset;
+}


### PR DESCRIPTION
fixes #203
fixes #314 

Changes:
  
- plugins/karma (disconnect_handler):
  - Counts a connection as naughty ($naughty++) when karma hits -strikes or the connection was flagged via is_naughty() — symmetric to the existing $nice++. The penalty-box threshold math is preserved (the old local $history-- equals nice - (naughty+1)).
  - Records a verdict when karma is non-zero or the connection is naughty-flagged, instead of bailing on neutral karma.
  - Added return DECLINED if $self->is_immune(); at the top. This is the pairing with the committed #203 fix: a whitelisted-but-flagged host is now neither disconnected by naughty nor recorded as naughty by karma — the two fixes stay consistent, and it makes the plugin's existing POD claim ("does not penalize connections with whitelisthost set") actually true.
  - POD: a short note that karma keeps no verdict of its own — counts stay empty unless another plugin drives karma or flags naughty (directly answering the #314 question).
- t/plugin_tests/karma (new): four tests — negative karma → naughty counted; naughty-flagged at neutral karma → counted; positive karma → nice counted; immune → not recorded. Verified they fail without the $naughty++ fix.
- t/config/plugins: added karma db_dir ./t/tmp so the test loads.