### PR TITLE
postfix: disable $qid debug output

### DIFF
--- a/lib/Qpsmtpd/Postfix.pm
+++ b/lib/Qpsmtpd/Postfix.pm
@@ -188,7 +188,7 @@ sub inject_mail {
 
     my %at  = $strm->get_attr;
     my $qid = $at{queue_id};
-    print STDERR "qid=$qid\n";
+    #print STDERR "qid=$qid\n";
     $strm->print_attr('flags' => $transaction->notes('postfix-queue-flags'));
     $strm->print_rec_time();
     $strm->print_rec('REC_TYPE_FROM', $transaction->sender->address || "");


### PR DESCRIPTION
The Qpsmtpd::Postfix module prints `qid=$qid` to STDERR which ends up in logs.  It's not particularly useful without context, disable as we did for headers in 3012033 (postfix: avoid logging full headers (#319), 2024-04-05).